### PR TITLE
Resolves issue #9 with same rules with different arguments getting overwritten

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -99,7 +99,7 @@ function _executeRules(options, value, key, prefix, errors, deepQueue, ruleQueue
       let rule = _this.parent.rules[ruleKey] || defaultRules[ruleKey];
       // Asynchronous rules get added to the queue
       if (rule.async) {
-        ruleQueue[ruleKey] = ((r, key, val, rVal) => {
+        ruleQueue[ruleKey + '_' + ruleValue] = ((r, key, val, rVal) => {
           return next => {
             r(val, rVal, err => {
               next(null, { err: err, key: key });


### PR DESCRIPTION
Multiple attributes with the same rule, but different arguments to the rule are overwritten. The index on the list of rules is by rule name,
and doesn't take into account different rule arguments.

This fix appends an '_' + ruleValue to the dictionary of rules to
make same rules with different arguments unique.