### PR TITLE
return when no schemaRules are set (ie8 compat)

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -17,7 +17,9 @@ function _executeRulesSync(targetKey, options, errors, value, key) {
   let nestedKey = targetKey + (targetKey.length ? '.' : '') + key;
   let schemaRules = utils.get(this.schema, nestedKey);
 
-  if (utils.isObject(value) || hasObject(schemaRules)) {
+  if (!schemaRules) {
+    return;
+  } else if (utils.isObject(value) || hasObject(schemaRules)) {
     let err = _validateSync.apply(this, [nestedKey, value || {}, options]);
     if (err) {
       errors[key] = err;
@@ -85,7 +87,9 @@ function _executeRules(options, value, key, prefix, errors, deepQueue, ruleQueue
   let nestedKey = prefix + key;
   let schemaRules = utils.get(this.schema, nestedKey);
 
-  if (utils.isObject(value) || hasObject(schemaRules)) {
+  if (!schemaRules) {
+    return;
+  } else if (utils.isObject(value) || hasObject(schemaRules)) {
     // Recurse down into nested attributes
     deepQueue[key] = ((nK, val) => {
       return next => {


### PR DESCRIPTION
- `hasObject` fails on IE8 when `schemaRules` is undefined
- return early when `schemaRules` aren't set for a field
  https://github.com/js-data/js-data-schema/issues/18
